### PR TITLE
Make Mobile Beacons not stupid

### DIFF
--- a/NotInMyBackYard/NIMBY.csproj
+++ b/NotInMyBackYard/NIMBY.csproj
@@ -54,6 +54,8 @@
     <Compile Include="NotInMyBackYard.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="UnloadedMobileBeacon.cs" />
+    <Compile Include="NIMBYEvent.cs" />
+    <Compile Include="NimbyScenario.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="AssemblyVersion.tt">

--- a/NotInMyBackYard/NIMBYEvent.cs
+++ b/NotInMyBackYard/NIMBYEvent.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace NotInMyBackYard
+{
+    [KSPAddon(KSPAddon.Startup.MainMenu, true)]
+    public class NIMBYEvent : MonoBehaviour
+    {
+        public static EventData<Vessel> OnVesselsTagged;
+        public static NIMBYEvent Instance;
+        public List<Guid> taggedVessels = new List<Guid>();
+        private void Awake()
+        {
+            DontDestroyOnLoad(this);
+            OnVesselsTagged = new EventData<Vessel>("OnVesselsTagged");
+            Instance = this;
+        }
+
+        public void TagVessel(Vessel v)
+        {
+            if (taggedVessels.Contains(v.id)) return;
+            taggedVessels.Add(v.id);
+            ScreenMessages.PostScreenMessage(v.vesselName + " marked for recovery");
+            Debug.Log("[NIMBY]: "+v.vesselName+" tagged for recovery");
+        }
+    }
+}

--- a/NotInMyBackYard/NIMBYScenario.cs
+++ b/NotInMyBackYard/NIMBYScenario.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Linq;
+
+namespace NotInMyBackYard
+{
+    [KSPScenario(ScenarioCreationOptions.AddToAllGames, GameScenes.FLIGHT, GameScenes.TRACKSTATION)]
+    public class NIMBYScenario : ScenarioModule
+    {
+        public override void OnLoad(ConfigNode node)
+        {
+            NIMBYEvent.Instance.taggedVessels.Clear();
+            string[] taggedVessels = node.GetValues("taggedVessel");
+            for (int i = 0; i < taggedVessels.Length; i++)
+            {
+                string s = taggedVessels.ElementAt(i);
+                NIMBYEvent.Instance.taggedVessels.Add(new Guid(s));
+            }
+        }
+
+        public override void OnSave(ConfigNode node)
+        {
+            for (int i = 0; i < NIMBYEvent.Instance.taggedVessels.Count; i++)
+            {
+                node.AddValue("taggedVessel", NIMBYEvent.Instance.taggedVessels.ElementAt(i));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Sorry it's taken so long, I scaled back alot of my bigger ideas because they just didn't work from a gameplay perspective.

So: 
First of all, Mobile Beacons no longer require a sacrifice to the gods, and a ground base to actually work.

I get what Magico13 was going for, but I don't think it works. I think this mod works best with something like KerbalKonstructs where you can launch a "spotter plane" to pick up the pod that you just dropped, and then fly back to a base.

Of course, water landings == death so actually *making* the player land to recover (because they would lose their plane by switching) didn't seem like a good idea either.

So actual changes:
- Mobile Beacon range upped to 10k and the requirements for a Lab and an Engineer have been dropped.
- Mobile Beacon now actually shows in the command modules right click menu.
- New KSPEvent - "Tag for Recovery" - the basic idea here, is that rather than landing, you can do a  low pass  over the vessel you are trying to recover, 'tag' it through the right click menu and then fly back to base. Because they have been "tagged" by the spotter, they can still be recovered. (This is complimented by a GameEvent that fires when a vessel tries to tag, so each vessel just handles it's own tagging)
- Added a scenario module to save which vessels have been tagged.

Feel free to tell me if you hate it, but I think it really improves the gameplay (and it's how I expected this mod to work before I read the source).

I'm also working on a plugin that automatically makes a Beacon File for all Kerbal Konstruct bases, but it's not ready yet.