### PR TITLE
DatedQuickSaves: difficulty section settings, localization, and other

### DIFF
--- a/DatedQuickSaves/DatedQuickSaves.cs
+++ b/DatedQuickSaves/DatedQuickSaves.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
-using System.Configuration;
 
 namespace DatedQuickSaves
 {
@@ -61,7 +60,6 @@ namespace DatedQuickSaves
 
             if (new_settings != settings)
             {
-                Logger.Log("new_settings != settings");
 
                 if (settings.StockNeedUpdate(new_settings))
                 {
@@ -72,7 +70,6 @@ namespace DatedQuickSaves
 
                 if (settings.NeedUpdateAndEnabling(new_settings))
                 {
-                    Logger.Log("NeedUpdateAndEnabling");
                     config = new Configuration();
                     GetKnownFiles();
                 }
@@ -138,8 +135,8 @@ namespace DatedQuickSaves
             if (System.IO.File.Exists(fname))
             {
                 int cnt = 0;
-                while (System.IO.File.Exists(SaveFolder + newName + "-" + cnt.ToString() + ".sfs") ||
-                    System.IO.File.Exists(SaveFolder + newName + "-" + cnt.ToString() + ".loadmeta"))
+                while (File.Exists(SaveFolder + newName + "-" + cnt.ToString() + ".sfs") ||
+                    File.Exists(SaveFolder + newName + "-" + cnt.ToString() + ".loadmeta"))
                     cnt++;
                 newName = newName + "-" + cnt.ToString();
                 fname = SaveFolder + newName;
@@ -196,7 +193,7 @@ namespace DatedQuickSaves
             SavedQSFiles.Clear();
             SavedASFiles.Clear();
             string saveFolder = SaveFolder;
-            if (System.IO.File.Exists(saveFolder + "DQS_DataBase.cfg"))
+            if (File.Exists(saveFolder + "DQS_DataBase.cfg"))
             {
                 ConfigNode database = ConfigNode.Load(saveFolder + "DQS_DataBase.cfg");
                 ConfigNode QSDB, ASDB;
@@ -255,6 +252,7 @@ namespace DatedQuickSaves
             int tgtQS = settings.MaxQuickSaveCount;
             int tgtAS = settings.MaxAutoSaveCount;
 
+
             string saveFolder = SaveFolder;
             int purgedQS = 0, purgedAS = 0;
             if (tgtQS >= 0) //if negative, then keep all files
@@ -280,7 +278,7 @@ namespace DatedQuickSaves
                 }
             }
             if (purgedQS > 0 || purgedAS > 0)
-                Logger.Log("Purged " + purgedQS + " QuickSaves and " + purgedAS + " AutoSaves.");
+                Logger.Log($"Purged {purgedQS} of {SavedQSFiles.Count} QuickSaves and {purgedAS} of {SavedASFiles.Count} AutoSaves.");
         }
     }
 
@@ -310,18 +308,16 @@ namespace DatedQuickSaves
 
         public void ReLoad()
         {
+            string filename = KSPUtil.ApplicationRootPath + "/GameData/DatedQuickSaves/extra_settings.cfg";
 
-            string directory = KSPUtil.ApplicationRootPath + "/GameData/DatedQuickSaves/";
-            string filename = "extra_settings.cfg";
+            ConfigNode cfg = ConfigNode.Load(filename).GetNode("DQS");
 
-            ConfigNode cfg = ConfigNode.Load(directory + filename).GetNode("DQS");
-
-            Logger.Log($"Lenght: {cfg.GetValues().Length}");
             cfg.TryGetValue("DateString", ref dateFormat);
             cfg.TryGetValue("QuickSaveTemplate", ref quickSaveTemplate);
             cfg.TryGetValue("AutoSaveTemplate", ref autoSaveTemplate);
 
-            Logger.Log($"quickSaveTemplate: {quickSaveTemplate}");
+            Logger.Log("Reload DQS Config");
+            ScreenMessages.PostScreenMessage("Reload DQS Config");
         }
     }
     
@@ -382,8 +378,7 @@ namespace DatedQuickSaves
             if (new_settings == null) return false;
 
             return QuickSaveNeedUpdate(new_settings) 
-                && new_settings.QuickSaveEnable
-                ;
+                && new_settings.QuickSaveEnable;
         }
 
         public bool AutoSaveNeedUpdate(Settings new_settings)

--- a/DatedQuickSaves/DatedQuickSaves.cs
+++ b/DatedQuickSaves/DatedQuickSaves.cs
@@ -48,8 +48,6 @@ namespace DatedQuickSaves
 
         void OnGameSettingsApplied()
         {
-            Logger.Log("OnGameSettingsApplied");
-
             if (config != null && HighLogic.CurrentGame.Parameters.CustomParams<DQSSettings>().ReloadExtra)
             {
                 config.ReLoad();
@@ -60,14 +58,6 @@ namespace DatedQuickSaves
 
             if (new_settings != settings)
             {
-
-                if (settings.StockNeedUpdate(new_settings))
-                {
-                    GameSettings.AUTOSAVE_INTERVAL = new_settings.StockAutosaveInterval;
-                    GameSettings.AUTOSAVE_SHORT_INTERVAL = new_settings.StockAutosaveShortInterval;
-                    GameSettings.SaveSettings();
-                }
-
                 if (settings.NeedUpdateAndEnabling(new_settings))
                 {
                     config = new Configuration();
@@ -175,7 +165,7 @@ namespace DatedQuickSaves
             string newName = MagiCore.StringTranslation.AddFormatInfo(config.autoSaveTemplate, "DatedQuickSaves", config.dateFormat);
             string relpath = Path.Combine("saves", HighLogic.SaveFolder, newName);
 
-            Logger.LogFormat("AutoSaving started to {0}. Tracking {1} autosaves.", relpath, SavedASFiles.Count);
+            //Logger.LogFormat("AutoSaving started to {0}. Tracking {1} autosaves.", relpath, SavedASFiles.Count);
 
             GamePersistence.SaveGame(newName, HighLogic.SaveFolder, SaveMode.OVERWRITE);
             SavedASFiles.Add(newName);
@@ -335,13 +325,9 @@ namespace DatedQuickSaves
         public int AutoSaveFreq;
         public int MaxAutoSaveCount;
 
-        public int StockAutosaveInterval;
-        public int StockAutosaveShortInterval;
-
         public Settings()
         {
             var settings = HighLogic.CurrentGame.Parameters.CustomParams<DQSSettings>();
-            var settings2 = HighLogic.CurrentGame.Parameters.CustomParams<DQSSettings2>();
 
             QuickSaveEnable = settings.QuickSaveEnable;
             StockQuickSaveRename = settings.StockQuickSaveRename;
@@ -353,18 +339,8 @@ namespace DatedQuickSaves
             AutoSaveFreq = settings.AutoSaveFreq;
             AutoSaveOnStart = settings.AutoSaveOnStart;
             MaxAutoSaveCount = settings.MaxAutoSaveCount;
-
-            StockAutosaveInterval = settings2.StockAutosaveInterval * 60;
-            StockAutosaveShortInterval = settings2.StockAutosaveShortInterval;
         }
 
-        public bool StockNeedUpdate(Settings new_settings)
-        {
-            if (new_settings == null) return false;
-
-            return StockAutosaveInterval != new_settings.StockAutosaveInterval
-                || StockAutosaveShortInterval != new_settings.StockAutosaveShortInterval;
-        }
 
         public bool QuickSaveNeedUpdate(Settings new_settings)
         {

--- a/DatedQuickSaves/DatedQuickSaves.csproj
+++ b/DatedQuickSaves/DatedQuickSaves.csproj
@@ -53,6 +53,7 @@
     <Compile Include="DatedQuickSaves.cs" />
     <Compile Include="InstallChecker.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="settings.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="AssemblyVersion.tt">

--- a/DatedQuickSaves/settings.cs
+++ b/DatedQuickSaves/settings.cs
@@ -1,0 +1,121 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using KSP.Localization;
+
+namespace DatedQuickSaves
+{
+    // http://forum.kerbalspaceprogram.com/index.php?/topic/147576-modders-notes-for-ksp-12/#DQS_comment-2754813
+    // search for "Mod integration into Stock Settings
+
+    public class DQSSettings : GameParameters.CustomParameterNode
+    {
+        public override string Title { get { return Localizer.Format("#autoLOC_149458"); } }
+        public override GameParameters.GameMode GameMode { get { return GameParameters.GameMode.ANY; } }
+        public override string Section { get { return "Dated Quick Save"; } }
+        public override string DisplaySection { get { return "Dated Quick Save"; } }
+        public override int SectionOrder { get { return 1; } }
+        public override bool HasPresets { get { return false; } }
+
+        [GameParameters.CustomStringParameterUI("#DQS_QuickSave", toolTip = "", lines = 1)]
+        public string QuickSave = "";
+
+        [GameParameters.CustomParameterUI("#DQS_QuickSaveEnable", toolTip = "")]
+        public bool QuickSaveEnable = true;
+
+        [GameParameters.CustomParameterUI("#DQS_ForcedQuickSave", toolTip = "#DQS_ForcedQuickSave_t")]
+        public bool QuickSaveForce = true;
+
+        [GameParameters.CustomParameterUI("#DQS_StockQuickSaveRename", toolTip = "#DQS_StockQuickSaveRename_t")]
+        public bool StockQuickSaveRename = true;
+
+        [GameParameters.CustomIntParameterUI("#DQS_MaxQuickSaveCount", toolTip = "#DQS_MaxQuickSaveCount_t", 
+            minValue = -1, maxValue = 50)]
+        public int MaxQuickSaveCount = 20;
+
+        [GameParameters.CustomIntParameterUI("#DQS_QuickSaveDelay", toolTip = "#DQS_QuickSaveDelay_t", 
+            minValue = 500, maxValue = 15000, stepSize =500)]
+        public int QuickSaveDelayMS = 1000;
+
+        [GameParameters.CustomIntParameterUI("#DQS_QuickSaveDelay2", toolTip = "#DQS_QuickSaveDelay2_t",
+    minValue = 500, maxValue = 15000, stepSize = 500)]
+        public int QuickSaveDelay2MS = 5000;
+
+
+        [GameParameters.CustomStringParameterUI("#DQS_AutoSave", toolTip = "", lines = 1)]
+        public string AutoSave = "";
+
+        [GameParameters.CustomParameterUI("#DQS_AutoSaveEnable", toolTip = "")]
+        public bool AutoSaveEnable = true;
+
+        [GameParameters.CustomParameterUI("#DQS_AutoSaveOnStart", toolTip = "#DQS_AutoSaveOnStart_t")]
+        public bool AutoSaveOnStart = false;
+
+        [GameParameters.CustomIntParameterUI("#DQS_AutoSaveFreq", toolTip = "", minValue = 1, maxValue = 180)]
+        public int AutoSaveFreq = 15;
+
+        [GameParameters.CustomIntParameterUI("#DQS_MaxAutoSaveCount", toolTip = "#DQS_MaxAutoSaveCount_t", minValue = -1, maxValue = 50)]
+        public int MaxAutoSaveCount = 20;
+
+
+
+
+
+        [GameParameters.CustomStringParameterUI("#DQS_Note1", toolTip = "", lines = 2)]
+        public string note1 = "";
+
+        [GameParameters.CustomParameterUI("#DQS_ReloadExtra", toolTip = "#DQS_ReloadExtra_t")]
+        public bool ReloadExtra = false;
+
+
+        public override bool Enabled(MemberInfo member, GameParameters parameters)
+        {
+            if (member.Name == nameof(QuickSaveDelay2MS))
+                return !QuickSaveForce;
+
+            return true;
+        }
+
+        public override bool Interactible(MemberInfo member, GameParameters parameters)
+        {
+            if (member.Name == nameof(MaxQuickSaveCount)
+                || member.Name == nameof(QuickSaveForce)
+                || member.Name == nameof(StockQuickSaveRename)
+                || member.Name == nameof(QuickSaveDelayMS)
+                || member.Name == nameof(QuickSaveDelay2MS)
+                )
+                return QuickSaveEnable;
+
+            if (member.Name == nameof(AutoSaveOnStart)
+                || member.Name == nameof(AutoSaveFreq)
+                || member.Name == nameof(MaxAutoSaveCount)
+                )
+                return AutoSaveEnable;
+
+            return true;
+        }
+    }
+
+    public class DQSSettings2 : GameParameters.CustomParameterNode
+    {
+        public override string Title { get { return Localizer.Format("#autoLOC_149458"); } }
+        public override GameParameters.GameMode GameMode { get { return GameParameters.GameMode.ANY; } }
+        public override string Section { get { return "Dated Quick Save"; } }
+        public override string DisplaySection { get { return "Dated Quick Save"; } }
+        public override int SectionOrder { get { return 2; } }
+        public override bool HasPresets { get { return false; } }
+
+        [GameParameters.CustomStringParameterUI("#DQS_Note2", toolTip = "", lines = 4)]
+        public string note2 = "";
+
+        [GameParameters.CustomIntParameterUI("#DQS_StockAutosaveInterval", toolTip = "#DQS_StockAutosaveInterval_t",
+minValue = 1, maxValue = 180, stepSize = 1)]
+        public int StockAutosaveInterval = 5;
+
+        [GameParameters.CustomIntParameterUI("#DQS_StockAutosaveShortInterval", toolTip = "#DQS_StockAutosaveShortInterval_t",
+    minValue = 10, maxValue = 1800, stepSize = 10)]
+        public int StockAutosaveShortInterval = 30;
+
+
+    }
+}

--- a/DatedQuickSaves/settings.cs
+++ b/DatedQuickSaves/settings.cs
@@ -23,9 +23,6 @@ namespace DatedQuickSaves
         [GameParameters.CustomParameterUI("#DQS_QuickSaveEnable", toolTip = "")]
         public bool QuickSaveEnable = true;
 
-        [GameParameters.CustomParameterUI("#DQS_ForcedQuickSave", toolTip = "#DQS_ForcedQuickSave_t")]
-        public bool QuickSaveForce = true;
-
         [GameParameters.CustomParameterUI("#DQS_StockQuickSaveRename", toolTip = "#DQS_StockQuickSaveRename_t")]
         public bool StockQuickSaveRename = true;
 
@@ -36,11 +33,6 @@ namespace DatedQuickSaves
         [GameParameters.CustomIntParameterUI("#DQS_QuickSaveDelay", toolTip = "#DQS_QuickSaveDelay_t", 
             minValue = 500, maxValue = 15000, stepSize =500)]
         public int QuickSaveDelayMS = 1000;
-
-        [GameParameters.CustomIntParameterUI("#DQS_QuickSaveDelay2", toolTip = "#DQS_QuickSaveDelay2_t",
-    minValue = 500, maxValue = 15000, stepSize = 500)]
-        public int QuickSaveDelay2MS = 5000;
-
 
         [GameParameters.CustomStringParameterUI("#DQS_AutoSave", toolTip = "", lines = 1)]
         public string AutoSave = "";
@@ -57,10 +49,6 @@ namespace DatedQuickSaves
         [GameParameters.CustomIntParameterUI("#DQS_MaxAutoSaveCount", toolTip = "#DQS_MaxAutoSaveCount_t", minValue = -1, maxValue = 50)]
         public int MaxAutoSaveCount = 20;
 
-
-
-
-
         [GameParameters.CustomStringParameterUI("#DQS_Note1", toolTip = "", lines = 2)]
         public string note1 = "";
 
@@ -70,19 +58,14 @@ namespace DatedQuickSaves
 
         public override bool Enabled(MemberInfo member, GameParameters parameters)
         {
-            if (member.Name == nameof(QuickSaveDelay2MS))
-                return !QuickSaveForce;
-
             return true;
         }
 
         public override bool Interactible(MemberInfo member, GameParameters parameters)
         {
             if (member.Name == nameof(MaxQuickSaveCount)
-                || member.Name == nameof(QuickSaveForce)
                 || member.Name == nameof(StockQuickSaveRename)
                 || member.Name == nameof(QuickSaveDelayMS)
-                || member.Name == nameof(QuickSaveDelay2MS)
                 )
                 return QuickSaveEnable;
 

--- a/DatedQuickSaves/settings.cs
+++ b/DatedQuickSaves/settings.cs
@@ -78,27 +78,4 @@ namespace DatedQuickSaves
             return true;
         }
     }
-
-    public class DQSSettings2 : GameParameters.CustomParameterNode
-    {
-        public override string Title { get { return Localizer.Format("#autoLOC_149458"); } }
-        public override GameParameters.GameMode GameMode { get { return GameParameters.GameMode.ANY; } }
-        public override string Section { get { return "Dated Quick Save"; } }
-        public override string DisplaySection { get { return "Dated Quick Save"; } }
-        public override int SectionOrder { get { return 2; } }
-        public override bool HasPresets { get { return false; } }
-
-        [GameParameters.CustomStringParameterUI("#DQS_Note2", toolTip = "", lines = 4)]
-        public string note2 = "";
-
-        [GameParameters.CustomIntParameterUI("#DQS_StockAutosaveInterval", toolTip = "#DQS_StockAutosaveInterval_t",
-minValue = 1, maxValue = 180, stepSize = 1)]
-        public int StockAutosaveInterval = 5;
-
-        [GameParameters.CustomIntParameterUI("#DQS_StockAutosaveShortInterval", toolTip = "#DQS_StockAutosaveShortInterval_t",
-    minValue = 10, maxValue = 1800, stepSize = 10)]
-        public int StockAutosaveShortInterval = 30;
-
-
-    }
 }

--- a/GameData/DatedQuickSaves/extra_settings.cfg
+++ b/GameData/DatedQuickSaves/extra_settings.cfg
@@ -1,0 +1,30 @@
+// the majority of mod settings is placed in the difficulty section.
+// This is extra mod settings.
+
+// It's recommended to not edit this file and use a Module Manager patch to change the values.
+// Patched extra settings takes effect after restarting the game.
+// Also you could change the settings there, and reload it using the difficulty section button.
+
+DQS
+{
+	DateString = yyyy-MM-dd-HHmmss
+	QuickSaveTemplate = Y[year]D[day0]_[hour0][min0][sec0]_QS_[vessel]
+	AutoSaveTemplate = Y[year]D[day0]_[hour0][min0][sec0]_AS_[vessel]
+}
+
+// Available params:
+
+//[date]      = Parsed DQS/DateString value (Realtime)
+
+//[year][day][hour][min][sec]      = Current in-game year, day, hour, min, sec (as seen in top left during flight)
+//[year0][day0][hour0][min0][sec0] = Same, but zero padded
+//[UT]        = Current in-game time in seconds
+//[kspDate]   = Current in-game date (example: "Year 1, Day 12")
+//[MET﻿]       = Active vessel's mission elapsed time. (Y-D-HH-MM-SS)
+
+//[save]      = Name of current save game
+//[version]   = KSP version
+//[vessel]    = Active Vessel name
+//[body]      = Current primary celestial body name
+//[biome]     = Current Active Vessel biome
+//[situation] = Active Vessel situation (PRELAUNCH, FLYING, ORBITING, etc.)

--- a/GameData/DatedQuickSaves/localization/en-us.cfg
+++ b/GameData/DatedQuickSaves/localization/en-us.cfg
@@ -1,0 +1,38 @@
+﻿Localization
+{
+	en-us
+	{
+		#DQS_QuickSave            = QuickSave
+        #DQS_QuickSaveEnable      = Enable QuickSave    
+		#DQS_ForcedQuickSave      = Force QuickSave
+		#DQS_ForcedQuickSave_t    = Force Dated Quicksave even if stock quicksave failed (example: moving rover/plane) 
+        #DQS_MaxQuickSaveCount    = QuickSave Max Count  
+		#DQS_MaxQuickSaveCount_t  = Purge extraneous saves. If negative, then keep all saves
+        #DQS_StockQuickSaveRename = Stock QuickSave Rename
+		#DQS_StockQuickSaveRename_t = Rename quicksave.sfs or copy it\n - "Rename" is quicker, but prevents from F9 quickload,\n - "Copy" supports F9 quickload, but also "Copy" will be run on Alt+F5 or Esc/Save Game  
+		#DQS_QuickSaveDelay       = QuickSave Delay (msec)
+		#DQS_QuickSaveDelay_t     = Delay between pressing F5 and attempting to make dated quicksave (in-game milliseconds)
+		#DQS_QuickSaveDelay2       = quicksave.sfs marge to be old (msec)
+		#DQS_QuickSaveDelay2_t     = Time marge for a quicksave.sfs to be considered old, and unable to be datedquicksaved (realworld milliseconds)
+		
+		
+		#DQS_AutoSave             = AutoSave
+        #DQS_AutoSaveEnable       = Enable AutoSave      
+        #DQS_AutoSaveOnStart      = First AutoSave On Scene Load
+		#DQS_AutoSaveOnStart_t    = First AutoSave on scene load or after specified amount of minutes
+        #DQS_AutoSaveFreq         = AutoSave Frequency (min)        
+        #DQS_MaxAutoSaveCount     = AutoSave Max Count    
+		#DQS_MaxAutoSaveCount_t   = Purge extraneous saves. If negative, then keep all saves
+		#DQS_Note1                = :Check GameData/DatedQuickSaves/ for extra-settings.cfg
+		#DQS_ReloadExtra          = Reload extra-settings.cfg
+		#DQS_ReloadExtra_t        = Enable and Accept for reloading only the extra-settings.cfg (MM-patches is ignored (if any))
+		
+		
+		#DQS_Note2                        = Hidden stock settings of a stock autosave to the persistent.sfs (can be found in the settings.cfg)
+		#DQS_StockAutosaveInterval        = Stock Autosave Interval (min)
+		#DQS_StockAutosaveInterval_t      = 
+		#DQS_StockAutosaveShortInterval   = Stock Autosave Short Interval (sec)
+		#DQS_StockAutosaveShortInterval_t = That's the time interval for another attempt at saving,\nin case the first attempt fails. If the auto save fails,\nit will continuously retry on that interval until it's able to save again.
+        
+	}
+}

--- a/GameData/DatedQuickSaves/localization/en-us.cfg
+++ b/GameData/DatedQuickSaves/localization/en-us.cfg
@@ -2,35 +2,32 @@
 {
 	en-us
 	{
-		#DQS_QuickSave            = QuickSave
-        #DQS_QuickSaveEnable      = Enable QuickSave
-        #DQS_MaxQuickSaveCount    = QuickSave Max Count  
+		#DQS_QuickSave			  = QuickSave
+		#DQS_QuickSaveEnable	  = Enable QuickSave
+		#DQS_MaxQuickSaveCount	  = QuickSave Max Count	 
 		#DQS_MaxQuickSaveCount_t  = Purge extraneous saves. If negative, then keep all saves
-        #DQS_StockQuickSaveRename = Stock QuickSave Rename
-		#DQS_StockQuickSaveRename_t = Rename quicksave.sfs or copy it\n - "Rename" is quicker, but prevents from F9 quickload,\n - "Copy" supports F9 quickload, but also "Copy" will be run on Alt+F5 or Esc/Save Game  
-		#DQS_QuickSaveDelay       = QuickSave Delay (msec)
-		#DQS_QuickSaveDelay_t     = Delay between pressing F5 and attempting to make dated quicksave (in-game milliseconds)
-		#DQS_QuickSaveDelay2       = quicksave.sfs marge to be old (msec)
-		#DQS_QuickSaveDelay2_t     = Time marge for a quicksave.sfs to be considered old, and unable to be datedquicksaved (realworld milliseconds)
+		#DQS_StockQuickSaveRename = Stock QuickSave Rename
+		#DQS_StockQuickSaveRename_t = Rename quicksave.sfs or copy it\n - "Rename" is quicker, but prevents from F9 quickload,\n - "Copy" supports F9 quickload.  
+		#DQS_QuickSaveDelay		  = QuickSave Delay (msec)
+		#DQS_QuickSaveDelay_t	  = Delay between pressing F5 and attempting to make dated quicksave (in-game milliseconds)
+		
+		#DQS_AutoSave			  = AutoSave
+		#DQS_AutoSaveEnable		  = Enable AutoSave		 
+		#DQS_AutoSaveOnStart	  = AutoSave On Scene Load
+		#DQS_AutoSaveOnStart_t	  = First AutoSave on scene load or only after specified amount of minutes
+		#DQS_AutoSaveFreq		  = AutoSave Frequency (min)		
+		#DQS_MaxAutoSaveCount	  = AutoSave Max Count	  
+		#DQS_MaxAutoSaveCount_t	  = Purge extraneous saves. If negative, then keep all saves
+		#DQS_Note1				  = :Check GameData/DatedQuickSaves/ for extra-settings.cfg
+		#DQS_ReloadExtra		  = Reload extra-settings.cfg
+		#DQS_ReloadExtra_t		  = Enable and Accept for reloading only the extra-settings.cfg (MM-patches is ignored (if any))
 		
 		
-		#DQS_AutoSave             = AutoSave
-        #DQS_AutoSaveEnable       = Enable AutoSave      
-        #DQS_AutoSaveOnStart      = First AutoSave On Scene Load
-		#DQS_AutoSaveOnStart_t    = First AutoSave on scene load or after specified amount of minutes
-        #DQS_AutoSaveFreq         = AutoSave Frequency (min)        
-        #DQS_MaxAutoSaveCount     = AutoSave Max Count    
-		#DQS_MaxAutoSaveCount_t   = Purge extraneous saves. If negative, then keep all saves
-		#DQS_Note1                = :Check GameData/DatedQuickSaves/ for extra-settings.cfg
-		#DQS_ReloadExtra          = Reload extra-settings.cfg
-		#DQS_ReloadExtra_t        = Enable and Accept for reloading only the extra-settings.cfg (MM-patches is ignored (if any))
-		
-		
-		#DQS_Note2                        = Hidden stock settings of a stock autosave to the persistent.sfs (can be found in the settings.cfg)
-		#DQS_StockAutosaveInterval        = Stock Autosave Interval (min)
-		#DQS_StockAutosaveInterval_t      = 
-		#DQS_StockAutosaveShortInterval   = Stock Autosave Short Interval (sec)
+		#DQS_Note2						  = Hidden stock settings of a stock autosave to the persistent.sfs (can be found in the settings.cfg)
+		#DQS_StockAutosaveInterval		  = Stock Autosave Interval (min)
+		#DQS_StockAutosaveInterval_t	  = 
+		#DQS_StockAutosaveShortInterval	  = Stock Autosave Short Interval (sec)
 		#DQS_StockAutosaveShortInterval_t = That's the time interval for another attempt at saving,\nin case the first attempt fails. If the auto save fails,\nit will continuously retry on that interval until it's able to save again.
-        
+		
 	}
 }

--- a/GameData/DatedQuickSaves/localization/en-us.cfg
+++ b/GameData/DatedQuickSaves/localization/en-us.cfg
@@ -3,9 +3,7 @@
 	en-us
 	{
 		#DQS_QuickSave            = QuickSave
-        #DQS_QuickSaveEnable      = Enable QuickSave    
-		#DQS_ForcedQuickSave      = Force QuickSave
-		#DQS_ForcedQuickSave_t    = Force Dated Quicksave even if stock quicksave failed (example: moving rover/plane) 
+        #DQS_QuickSaveEnable      = Enable QuickSave
         #DQS_MaxQuickSaveCount    = QuickSave Max Count  
 		#DQS_MaxQuickSaveCount_t  = Purge extraneous saves. If negative, then keep all saves
         #DQS_StockQuickSaveRename = Stock QuickSave Rename


### PR DESCRIPTION
DatedQuickSaves
- 	Switch to Difficulty Section settings and GameConfig settings (DQS node)
    - option to reload DQS node from the settings
- 	Add settings for disabling Quicksave or Autosave features
- 	Add localization
- 	Scale autosave period on Physic Time Warp
- 	Option for rename save file instead of copy